### PR TITLE
Get total hit count from ES

### DIFF
--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -1207,7 +1207,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 			$this->es_args = apply_filters_ref_array( 'es_posts_request', array( $this->es_args, &$this ) );
 		}
 
-		if ( 'ids' === $q['fields'] || 'id=>parent' === $q['fields'] ) {
+		if ( 'ids' === $q['fields'] || 'id=>parent' === $q['fields'] || apply_filters( 'es_query_use_source', false ) ) {
 			$this->es_response = $this->query_es( $this->es_args );
 			$this->set_posts( $q, $this->es_response );
 			$this->post_count = count( $this->posts );

--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -1202,6 +1202,9 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 			$size                  = apply_filters( 'es_query_max_results', 1000 );
 			$this->es_args['size'] = $size;
 		}
+		
+		// ES > 7.0 doesn't return the actual total hits by default (capped at 10k), but we need accurate counts
+		$this->es_args[ 'track_total_hits' ] = true;
 
 		if ( ! $q['suppress_filters'] ) {
 			$this->es_args = apply_filters_ref_array( 'es_posts_request', array( $this->es_args, &$this ) );


### PR DESCRIPTION
Elasticsearch after 7.0 doesn't return the total hits by default - it caps the count at 10k.

That reduces query times, but also makes the count inaccurate when more than 10k posts match, so we need to send the `track_total_hits` parameter.