### PR TITLE
Use raw field for post title in adapter

### DIFF
--- a/adapters/vip-search.php
+++ b/adapters/vip-search.php
@@ -133,7 +133,7 @@ function vip_es_field_map( $es_map ) {
 			'post_date_gmt.second'          => 'date_gmt_terms.second',
 			'post_content'                  => 'post_content',
 			'post_content.analyzed'         => 'post_content',
-			'post_title'                    => 'post_title',
+			'post_title'                    => 'post_title.raw',
 			'post_title.analyzed'           => 'post_title',
 			'post_type'                     => 'post_type.raw',
 			'post_excerpt'                  => 'post_excerpt',


### PR DESCRIPTION
## Description

Use `post_title.raw` rather than `post_title.` 

Since `fielddata` is off by default for text fields making sorting, aggregations, scripting, etc... on `post_title` not possible due to various issues that would present. 

The `raw` keyword field is an easy workaround for that issue and still lets `post_title` be used properly as an inverted index.

## Testing

1. Add to themes functions.php:
```
add_action( 'pre_get_posts', function( $q ) { 
  $q->set( 'es', true );
} );
```
2. Visit `http://vip-go-dev.lndo.site/wp-admin/edit.php` or equivalent.
3. You will get no results and an Elasticsearch error.
4. Apply PR.
5. Visit `http://vip-go-dev.lndo.site/wp-admin/edit.php` or equivalent.
6. It will load as you'd expect.