### PR TITLE
Use raw field for post name in adapter

### DIFF
--- a/adapters/vip-search.php
+++ b/adapters/vip-search.php
@@ -138,7 +138,7 @@ function vip_es_field_map( $es_map ) {
 			'post_type'                     => 'post_type.raw',
 			'post_excerpt'                  => 'post_excerpt',
 			'post_password'                 => 'post_password',  // This isn't indexed on VIP.
-			'post_name'                     => 'post_name',
+			'post_name'                     => 'post_name.raw',
 			'post_modified'                 => 'post_modified',
 			'post_modified.year'            => 'modified_date_terms.year',
 			'post_modified.month'           => 'modified_date_terms.month',


### PR DESCRIPTION
### Description

Similarly to #7, this changes the VIP Search adapter to use `post_name.raw` rather than `post_name`.

### Testing

1. Add to themes functions.php:
```
add_action( 'pre_get_posts', function( $q ) { 
    $q->set( 'es', true );
    $q->set( 'orderby', 'post_name' );
} );
```

2. Visit http://vip-go-dev.lndo.site/wp-admin/edit.php or equivalent.
1. You will get no results and an Elasticsearch error.
1. Apply PR.
1. Visit http://vip-go-dev.lndo.site/wp-admin/edit.php or equivalent.
1. It will load as you'd expect.