### PR TITLE
Fix is_main_query() not registering when hooked onto pre_get_posts

### DIFF
--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -24,7 +24,7 @@ add_filter( 'query_vars', 'es_wp_query_arg' );
  * If a WP_Query object has `'es' => true`, use Elasticsearch to run the meat of the query.
  * This is fires on the "pre_get_posts" action.
  *
- * @param  object $query WP_Query object.
+ * @param  WP_Query $query Current full WP_Query object.
  * @return void
  */
 function es_wp_query_shoehorn( &$query ) {
@@ -78,6 +78,7 @@ function es_wp_query_shoehorn( &$query ) {
 		 */
 		$es_query_args           = $query->query;
 		$es_query_args['fields'] = 'ids';
+		$es_query_args['es_is_main_query'] = $query->is_main_query();
 		$es_query                = new ES_WP_Query( $es_query_args );
 
 		// Make the post query use the post IDs from the ES results instead.

--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -44,6 +44,19 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 	abstract protected function query_es( $es_args );
 
 	/**
+	 * Override default WP_Query->is_main_query() to support
+	 * this conditional when the main query has been overridden
+	 * by this class.
+	 *
+	 * @fixes #38
+	 *
+	 * @return bool
+	 */
+	public function is_main_query() {
+		return $this->get( 'es_is_main_query', false );
+	}	
+
+	/**
 	 * Maps a field to its Elasticsearch context.
 	 *
 	 * @param string $field The field to map.


### PR DESCRIPTION
The issue has been occurring since 2016: #38

This PR duplicates the fix from #84 until merged upstream. Another way to resolve the issue is to not use `is_main_query()` but in some cases, that's not possible.