### PR TITLE
Use login field instead of display_name for cases where user's display_name does not match

### DIFF
--- a/adapters/vip-search.php
+++ b/adapters/vip-search.php
@@ -110,7 +110,7 @@ function vip_es_field_map( $es_map ) {
 	return wp_parse_args(
 		array(
 			'post_author'                   => 'post_author.id',
-			'post_author.user_nicename'     => 'post_author.login',
+			'post_author.user_nicename'     => 'post_author.login.raw',
 			'post_date'                     => 'post_date',
 			'post_date.year'                => 'date_terms.year',
 			'post_date.month'               => 'date_terms.month',

--- a/adapters/vip-search.php
+++ b/adapters/vip-search.php
@@ -110,7 +110,7 @@ function vip_es_field_map( $es_map ) {
 	return wp_parse_args(
 		array(
 			'post_author'                   => 'post_author.id',
-			'post_author.user_nicename'     => 'post_author.display_name',
+			'post_author.user_nicename'     => 'post_author.login',
 			'post_date'                     => 'post_date',
 			'post_date.year'                => 'date_terms.year',
 			'post_date.month'               => 'date_terms.month',


### PR DESCRIPTION
We should be using the login so that author queries become offloaded properly on es-wp-query.  Take this user use case for instance:

```
+-----------------+---------------------+
| Field           | Value               |
+-----------------+---------------------+
| ID              | 123456            |
| user_login      | kraftdinner              |
| user_email      | kraft@dinner.com    |
| user_registered | 2013-05-21 23:11:36 |
| display_name    | K.D.       |
| roles           |                     |
+-----------------+---------------------+
```

It will query like this:

```
'{"query":{"bool":{"filter":[{"term":{"post_author.display_name":"kraftdinner"}},{"term":{"post_type.raw":"post"}},{"terms":{"post_status":["publish"]}}]}},"sort":[{"post_date":"desc"}],"_source":["post_id"],"from":0,"size":10,"track_total_hits":true}'
```

Which will return 0 results due to the display_name not being `kraftdinner`, but `K.D.` rather.  When in fact, the query that will return results is:

```
'{"query":{"bool":{"filter":[{"term":{"post_author.login":"kraftdinner"}},{"term":{"post_type.raw":"post"}},{"terms":{"post_status":["publish"]}}]}},"sort":[{"post_date":"desc"}],"_source":["post_id"],"from":0,"size":10,"track_total_hits":true}'
```

Note: This PR relies on https://github.com/Automattic/ElasticPress/pull/68.